### PR TITLE
hostNetwork and initial pass/fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,19 @@
 # k8s-netperf - Kubernetes Network Performance
 Running Networking Performance Tests against K8s
 
+[![asciicast](https://asciinema.org/a/524925.svg)](https://asciinema.org/a/524925)
+
 ## Status
 Currently a work-in-progress.
+
+### Benchmark Tool and Tests
+
+| Tool | Test | Status | Pass/Fail Context |
+|------|------|--------|-------------------|
+| netperf | TCP_STREAM | Working | Yes |
+| netperf | UDP_STREAM | Working | No |
+| netperf | TCP_RR | Working | No |
+| netperf | TCP_CRR | Working | No|
 
 ## Setup
 ```shell
@@ -17,54 +28,89 @@ Ensure your `kubeconfig` is properly set to the cluster you would like to run `k
 also be sure to create a `netperf` namespace. (Not over-writable yet)
 
 ```shell
-$ ./k8s-netperf
+$ kubectl create ns netperf
+$ ./k8s-netperf -help
+Usage of ./k8s-netperf:
+  -config string
+        K8s netperf Configuration File (default "netperf.yml")
+  -local
+        Run Netperf with pod/server on the same node
+  -tcp-tolerance float
+        Allowed %diff from hostNetwork to podNetwork, anything above tolerance will result in k8s-netperf exiting 1. (default 10)
 ```
 
+### Config file
 `netperf.yml` contains a default set of tests.
-```yml
-TCPStream:
-   profile: "TCP_STREAM"
-   duration: 3
-   samples: 1
-   messagesize: 1024
 
-# TCPStream is a place-holder of a test name.
-# profile is the netperf profile to execute. This can be `[TCP,UDP]_STREAM, [TCP,UDP]_RR, TCP_CRR`
-# duration how long to run the test.
-# samples how many times to run the test
-# messagesize the size of the data-gram to send.
+Description of each field in the YAML.
+```yml
+TCPStream:                 # Place-holder of a test name
+   profile: "TCP_STREAM"   # Netperf profile to execute. This can be [TCP,UDP]_STREAM, [TCP,UDP]_RR, TCP_CRR
+   duration: 3             # How long to run the test
+   samples: 1              # Iterations to run specified test
+   messagesize: 1024       # Size of the data-gram
+   service: false          # If we should test with the server pod behind a service
 ```
+
+## Pass / Fail
+`k8s-netperf` has a cli option for `-tcp-tolerance` which defaults to 10%.
+
+In order to have `k8s-netperf` determine pass/fail the user must pass the `-all` flag. `k8s-netperf` must be able to run with hostNetwork and podNetwork across nodes.
+
+```shell
+$ ./k8s-netperf -tcp-tolerance 1
+--------------------------------------------------------------------- Stream Results ---------------------------------------------------------------------
+Scenario           | Host Network    |Service         | Message Size    | Same node       | Duration        | Samples         | Avg value
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
+📊 TCP_STREAM      | true            |false           | 16384           | false           | 10              | 3               | 923.180000      (Mb/s)
+📊 TCP_STREAM      | false           |false           | 16384           | false           | 10              | 3               | 881.770000      (Mb/s)
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
+😥 TCP Stream percent difference when comparing hostNetwork to podNetwork is greater than 1.0 percent (4.6 percent)
+$ echo $?
+1
+```
+
+| Tool | Test | pass/fail|
+|-----------|------|----------|
+| netperf | TCP_STREAM | working (default:10%) |
 
 ## Output
 `k8s-netperf` will provide updates to stdout of the operations it is running, such as creating the server/client deployments and the execution of the workload in the container.
 
 Same node refers to how the pods were deployed. If the cluster has > 2 nodes with nodes which have `worker=` there will be a cross-node throughput test.
 ```
------------------------------------------------------------ Stream Results -----------------------------------------------------------
-Scenario           | Service         | Message Size    | Same node       | Duration        | Samples         | Avg value
-----------------------------------------------------------------------------------------------------------------------------------------
-📊 UDP_STREAM      | false           | 16384           | false           | 10              | 1               | 3180.260000     (Mb/s)
-📊 TCP_STREAM      | false           | 16384           | false           | 10              | 1               | 846.200000      (Mb/s)
-----------------------------------------------------------------------------------------------------------------------------------------
--------------------------------------------------------------- RR Results --------------------------------------------------------------
-Scenario           | Service         | Message Size    | Same node       | Duration        | Samples         | Avg value
-----------------------------------------------------------------------------------------------------------------------------------------
-📊 TCP_CRR         | false           | 16384           | false           | 10              | 1               | 2534.770000     (OP/s)
-📊 TCP_CRR         | true            | 16384           | false           | 10              | 1               | 470.500000      (OP/s)
-📊 TCP_RR          | false           | 16384           | false           | 10              | 1               | 10065.760000    (OP/s)
-----------------------------------------------------------------------------------------------------------------------------------------
+--------------------------------------------------------------------- Stream Results ---------------------------------------------------------------------
+Scenario           | Host Network    |Service         | Message Size    | Same node       | Duration        | Samples         | Avg value
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
+📊 TCP_STREAM      | true            |false           | 16384           | false           | 10              | 3               | 923.360000      (Mb/s)
+📊 TCP_STREAM      | false           |false           | 16384           | false           | 10              | 3               | 882.310000      (Mb/s)
+📊 UDP_STREAM      | true            |false           | 16384           | false           | 10              | 3               | 943.440000      (Mb/s)
+📊 UDP_STREAM      | false           |false           | 16384           | false           | 10              | 3               | 3472.660000     (Mb/s)
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
+------------------------------------------------------------------------ RR Results ------------------------------------------------------------------------
+Scenario           | Host Network    |Service         | Message Size    | Same node       | Duration        | Samples         | Avg value
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
+📊 TCP_CRR         | false           |true            | 16384           | false           | 10              | 3               | 1969.860000     (OP/s)
+📊 TCP_RR          | true            |false           | 16384           | false           | 10              | 3               | 14952.600000    (OP/s)
+📊 TCP_RR          | false           |false           | 16384           | false           | 10              | 3               | 8862.240000     (OP/s)
+📊 TCP_CRR         | true            |false           | 16384           | false           | 10              | 3               | 3454.080000     (OP/s)
+📊 TCP_CRR         | false           |false           | 16384           | false           | 10              | 3               | 2332.390000     (OP/s)
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
 ```
 
 ### Output to CSV
 `k8s-netperf` will write a csv file, after it has completed the desired performance tests.
 
 Example output
+```csv
+Profile,Same node,Host Network,Service,Duration,# of Samples,Avg Throughput,Metric
+TCP_RR,false,true,false,10,3,15000.820000,OP/s
+TCP_RR,false,false,false,10,3,8120.030000,OP/s
+TCP_STREAM,false,true,false,10,3,926.450000,Mb/s
+TCP_STREAM,false,false,false,10,3,884.090000,Mb/s
+UDP_STREAM,false,true,false,10,3,933.370000,Mb/s
+UDP_STREAM,false,false,false,10,3,3459.930000,Mb/s
+TCP_CRR,false,true,false,10,3,3316.510000,OP/s
+TCP_CRR,false,false,false,10,3,2031.390000,OP/s
+TCP_CRR,false,false,true,10,3,19.200000,OP/s
 ```
-Profile,Same node,Service,Duration,# of Samples,Avg Throughput,Metric
-TCP_STREAM,false,false,10,1,894.030000,Mb/s
-UDP_STREAM,false,false,10,1,3297.260000,Mb/s
-TCP_CRR,false,false,10,1,2691.570000,OP/s
-TCP_CRR,false,true,10,1,1971.290000,OP/s
-TCP_RR,false,false,10,1,9504.450000,OP/s
-```
-

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -1,11 +1,13 @@
 FROM registry.access.redhat.com/ubi8:8.6
 
 COPY appstream.repo /etc/yum.repos.d/centos8-appstream.repo
-RUN dnf install -y --nodocs make --enablerepo=centos9 --allowerasing
-RUN dnf install -y --nodocs gcc --enablerepo=centos9 --allowerasing
-RUN curl -LO https://github.com/HewlettPackard/netperf/archive/refs/tags/netperf-2.7.0.tar.gz
-RUN tar -xzf netperf-2.7.0.tar.gz
-WORKDIR /netperf-netperf-2.7.0
-RUN ./configure && make && make install
-RUN rm -rf /netperf-2.7.0.tar.gz /netperf-netperf-2.7.0
-RUN dnf remove -y gcc make
+RUN dnf install -y --nodocs make automake --enablerepo=centos9 --allowerasing
+RUN dnf install -y --nodocs gcc git --enablerepo=centos9 --allowerasing
+RUN git clone https://github.com/HewlettPackard/netperf
+WORKDIR netperf
+RUN git reset --hard 3bc455b23f901dae377ca0a558e1e32aa56b31c4 
+RUN ./autogen.sh
+RUN ./configure --enable-demo && make && make install
+WORKDIR ../
+RUN rm -rf netperf/
+RUN dnf remove gcc make automake git -y

--- a/netperf.go
+++ b/netperf.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"os"
 	"strings"
 
@@ -16,7 +17,8 @@ import (
 func main() {
 	cfgfile := flag.String("config", "netperf.yml", "K8s netperf Configuration File")
 	nl := flag.Bool("local", false, "Run Netperf with pod/server on the same node")
-	hn := flag.Bool("hostnet", false, "Run Netperf with pod/server on hostnet (must have two worker nodes)")
+	full := flag.Bool("all", false, "Run all tests scenarios - hostNet and podNetwork (if possible)")
+	tcpt := flag.Float64("tcp-tolerance", 10, "Allowed %diff from hostNetwork to podNetwork, anything above tolerance will result in k8s-netperf exiting 1.")
 	flag.Parse()
 	cfg, err := netperf.ParseConf(*cfgfile)
 	if err != nil {
@@ -39,10 +41,9 @@ func main() {
 		os.Exit(1)
 	}
 	s := netperf.PerfScenarios{
-		NodeLocal:   *nl,
-		HostNetwork: *hn,
-		RestConfig:  *rconfig,
-		Configs:     cfg,
+		NodeLocal:  *nl,
+		RestConfig: *rconfig,
+		Configs:    cfg,
 	}
 	// Get node count
 	nodes, err := client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: "node-role.kubernetes.io/worker="})
@@ -50,14 +51,17 @@ func main() {
 		log.Error(err)
 		os.Exit(1)
 	}
-	err = netperf.BuildSUT(client, &s)
-	if err != nil {
-		log.Error(err)
+	if !s.NodeLocal && len(nodes.Items) < 2 {
+		log.Error("Node count too low to run pod to pod across nodes.")
+		log.Error("To run k8s-netperf on a single node deployment pass -local.")
+		log.Error("		$ k8s-netperf -local")
 		os.Exit(1)
 	}
 
-	if !s.NodeLocal && len(nodes.Items) < 2 {
-		log.Error("Node count too low to run pod to pod across nodes.")
+	// Build the SUT (Deployments)
+	err = netperf.BuildSUT(client, &s)
+	if err != nil {
+		log.Error(err)
 		os.Exit(1)
 	}
 
@@ -80,6 +84,27 @@ func main() {
 			npr := netperf.Data{}
 			npr.Config = nc
 			npr.Metric = metric
+			npr.HostNetwork = true
+			if !nc.Service && *full {
+				for i := 0; i < nc.Samples; i++ {
+					r, err := netperf.Run(client, s.RestConfig, nc, s.ClientHost, s.ServerHost.Items[0].Status.PodIP)
+					if err != nil {
+						log.Error(err)
+						log.Error("Note : Running netperf with hostNetwork will require some host configuration -- poking a hole in the firewall.")
+						os.Exit(1)
+					}
+					nr, err := netperf.ParseResults(&r, nc)
+					if err != nil {
+						log.Error(err)
+						os.Exit(1)
+					}
+					npr.Summary = append(npr.Summary, nr)
+				}
+				sr.Results = append(sr.Results, npr)
+			}
+			npr = netperf.Data{}
+			npr.Config = nc
+			npr.Metric = metric
 			npr.SameNode = false
 			for i := 0; i < nc.Samples; i++ {
 				r, err := netperf.Run(client, s.RestConfig, nc, s.ClientAcross, serverIP)
@@ -87,7 +112,7 @@ func main() {
 					log.Error(err)
 					os.Exit(1)
 				}
-				nr, err := netperf.ParseResults(&r)
+				nr, err := netperf.ParseResults(&r, nc)
 				if err != nil {
 					log.Error(err)
 					os.Exit(1)
@@ -108,7 +133,7 @@ func main() {
 					log.Error(err)
 					os.Exit(1)
 				}
-				nr, err := netperf.ParseResults(&r)
+				nr, err := netperf.ParseResults(&r, nc)
 				if err != nil {
 					log.Error(err)
 					os.Exit(1)
@@ -123,6 +148,19 @@ func main() {
 	err = netperf.WriteCSVResult(sr)
 	if err != nil {
 		log.Error(err)
+		os.Exit(1)
+	}
+	// Initially we are just checking against TCP_STREAM results.
+	if netperf.CheckHostResults(sr) {
+		diff, err := netperf.TCPThroughputDiff(sr)
+		if err != nil {
+			fmt.Println("Unable to calculate difference between HostNetwork and PodNetwork")
+			os.Exit(1)
+		}
+		if diff < *tcpt {
+			os.Exit(0)
+		}
+		fmt.Printf("😥 TCP Stream percent difference when comparing hostNetwork to podNetwork is greater than %.1f percent (%.1f percent)\r\n", *tcpt, diff)
 		os.Exit(1)
 	}
 }

--- a/netperf/archive.go
+++ b/netperf/archive.go
@@ -43,13 +43,13 @@ func WriteCSVResult(r ScenarioResults) error {
 	}
 	archive := csv.NewWriter(fp)
 	defer archive.Flush()
-	data := []string{"Profile", "Same node", "Service", "Duration", "# of Samples", "Avg Throughput", "Metric"}
+	data := []string{"Profile", "Same node", "Host Network", "Service", "Duration", "# of Samples", "Avg Throughput", "Metric"}
 	if err := archive.Write(data); err != nil {
 		return fmt.Errorf("Failed to write archive to file")
 	}
 	for _, row := range r.Results {
 		avg, _ := average(row.Summary)
-		data := []string{row.Profile, fmt.Sprint(row.SameNode), fmt.Sprint(row.Service), strconv.Itoa(row.Duration), strconv.Itoa(row.Samples), fmt.Sprintf("%f", avg), row.Metric}
+		data := []string{row.Profile, fmt.Sprint(row.SameNode), fmt.Sprint(row.HostNetwork), fmt.Sprint(row.Service), strconv.Itoa(row.Duration), strconv.Itoa(row.Samples), fmt.Sprintf("%f", avg), row.Metric}
 		if err := archive.Write(data); err != nil {
 			return fmt.Errorf("Failed to write archive to file")
 		}

--- a/netperf/kubernetes.go
+++ b/netperf/kubernetes.go
@@ -88,6 +88,7 @@ func CreateDeployment(dp DeploymentParams, client *kubernetes.Clientset) (*appsv
 					Labels: dp.Labels,
 				},
 				Spec: apiv1.PodSpec{
+					HostNetwork: dp.HostNetwork,
 					Containers: []apiv1.Container{
 						{
 							Name:    dp.Name,
@@ -174,4 +175,12 @@ func CreateService(sp ServiceParams, client *kubernetes.Clientset) (*apiv1.Servi
 		},
 	}
 	return sc.Create(context.TODO(), service, metav1.CreateOptions{})
+}
+
+// DestroyDeployment cleans up a specific deployment
+func DestroyDeployment(client *kubernetes.Clientset, dp *appsv1.Deployment) error {
+	deletePolicy := metav1.DeletePropagationForeground
+	return client.AppsV1().Deployments(dp.Namespace).Delete(context.TODO(), dp.Name, metav1.DeleteOptions{
+		PropagationPolicy: &deletePolicy,
+	})
 }

--- a/netperf/result.go
+++ b/netperf/result.go
@@ -13,10 +13,11 @@ import (
 // Data describes the result data
 type Data struct {
 	Config
-	Metric   string
-	SameNode bool
-	Sample   float64
-	Summary  []float64
+	Metric      string
+	SameNode    bool
+	HostNetwork bool
+	Sample      float64
+	Summary     []float64
 }
 
 // ScenarioResults each scenario could have multiple results
@@ -24,8 +25,11 @@ type ScenarioResults struct {
 	Results []Data
 }
 
-// NetReg Regex for netperf
+// NetReg Regex for Netperf
 var NetReg = regexp.MustCompile(`\s+\d+\s+\d+\s+(\d+|\S+)\s+(\S+|\d+)\s+(\S+)+\s+(\S+)?`)
+
+// NetUDPReg, with UDP we need to capture what the server saw versus what the client sent
+var NetUDPReg = regexp.MustCompile(`(?m)^[0-9]+\s+\S+\s+\d+\s+(\S+)`)
 
 func average(vals []float64) (float64, error) {
 	return stats.Median(vals)
@@ -35,6 +39,8 @@ func percentile(vals []float64, ptile float64) (float64, error) {
 	return stats.Percentile(vals, ptile)
 }
 
+// CheckResults will check to see if there are results with a specific Profile like TCP_STREAM
+// returns true if there are results with provided string
 func checkResults(s ScenarioResults, check string) bool {
 	for t := range s.Results {
 		if strings.Contains(s.Results[t].Profile, check) {
@@ -44,19 +50,58 @@ func checkResults(s ScenarioResults, check string) bool {
 	return false
 }
 
+// checkHostResults will check to see if there are hostNet results
+// returns true if there are results with hostNetwork
+func CheckHostResults(s ScenarioResults) bool {
+	for t := range s.Results {
+		if s.Results[t].HostNetwork {
+			return true
+		}
+	}
+	return false
+}
+
+// TCPThroughputDiff accepts the Scenario Results and calculates the %diff.
+// returns
+func TCPThroughputDiff(s ScenarioResults) (float64, error) {
+	// We will focus on TCP STREAM
+	hostPerf := 0.0
+	podPerf := 0.0
+	for t := range s.Results {
+		if !s.Results[t].Service {
+			if s.Results[t].HostNetwork {
+				if s.Results[t].Profile == "TCP_STREAM" {
+					hostPerf, _ = average(s.Results[t].Summary)
+				}
+			} else {
+				if s.Results[t].Profile == "TCP_STREAM" {
+					podPerf, _ = average(s.Results[t].Summary)
+				}
+			}
+		}
+	}
+	return calDiff(hostPerf, podPerf), nil
+}
+
+// calDiff will determine the %diff between two values.
+// returns a float64 which is the %diff
+func calDiff(a float64, b float64) float64 {
+	return (a - b) / ((a + b) / 2) * 100
+}
+
 // ShowStreamResult accepts NetPerfResults to display to the user via stdout
 func ShowStreamResult(s ScenarioResults) {
 	if checkResults(s, "STREAM") {
-		fmt.Printf("%s Stream Results %s\r\n", strings.Repeat("-", 59), strings.Repeat("-", 59))
-		fmt.Printf("%-18s | %-15s | %-15s | %-15s | %-15s | %-15s | %-15s\r\n", "Scenario", "Service", "Message Size", "Same node", "Duration", "Samples", "Avg value")
-		fmt.Printf("%s\r\n", strings.Repeat("-", 136))
+		fmt.Printf("%s Stream Results %s\r\n", strings.Repeat("-", 69), strings.Repeat("-", 69))
+		fmt.Printf("%-18s | %-15s |%-15s | %-15s | %-15s | %-15s | %-15s | %-15s\r\n", "Scenario", "Host Network", "Service", "Message Size", "Same node", "Duration", "Samples", "Avg value")
+		fmt.Printf("%s\r\n", strings.Repeat("-", 155))
 		for _, r := range s.Results {
 			if strings.Contains(r.Profile, "STREAM") {
 				avg, _ := average(r.Summary)
-				fmt.Printf("📊 %-15s | %-15t | %-15d | %-15t | %-15d | %-15d | %-15f (%s) \r\n", r.Profile, r.Service, r.MessageSize, r.SameNode, r.Duration, r.Samples, avg, r.Metric)
+				fmt.Printf("📊 %-15s | %-15t |%-15t | %-15d | %-15t | %-15d | %-15d | %-15f (%s) \r\n", r.Profile, r.HostNetwork, r.Service, r.MessageSize, r.SameNode, r.Duration, r.Samples, avg, r.Metric)
 			}
 		}
-		fmt.Printf("%s\r\n", strings.Repeat("-", 136))
+		fmt.Printf("%s\r\n", strings.Repeat("-", 155))
 	}
 }
 
@@ -65,32 +110,40 @@ func ShowStreamResult(s ScenarioResults) {
 // TODO: Capture latency values
 func ShowRRResult(s ScenarioResults) {
 	if checkResults(s, "RR") {
-		fmt.Printf("%s RR Results %s\r\n", strings.Repeat("-", 62), strings.Repeat("-", 62))
-		fmt.Printf("%-18s | %-15s | %-15s | %-15s | %-15s | %-15s | %-15s\r\n", "Scenario", "Service", "Message Size", "Same node", "Duration", "Samples", "Avg value")
-		fmt.Printf("%s\r\n", strings.Repeat("-", 136))
+		fmt.Printf("%s RR Results %s\r\n", strings.Repeat("-", 72), strings.Repeat("-", 72))
+		fmt.Printf("%-18s | %-15s |%-15s | %-15s | %-15s | %-15s | %-15s | %-15s\r\n", "Scenario", "Host Network", "Service", "Message Size", "Same node", "Duration", "Samples", "Avg value")
+		fmt.Printf("%s\r\n", strings.Repeat("-", 155))
 		for _, r := range s.Results {
 			if strings.Contains(r.Profile, "RR") {
 				avg, _ := average(r.Summary)
-				fmt.Printf("📊 %-15s | %-15t | %-15d | %-15t | %-15d | %-15d | %-15f (%s) \r\n", r.Profile, r.Service, r.MessageSize, r.SameNode, r.Duration, r.Samples, avg, r.Metric)
+				fmt.Printf("📊 %-15s | %-15t |%-15t | %-15d | %-15t | %-15d | %-15d | %-15f (%s) \r\n", r.Profile, r.HostNetwork, r.Service, r.MessageSize, r.SameNode, r.Duration, r.Samples, avg, r.Metric)
 			}
 		}
-		fmt.Printf("%s\r\n", strings.Repeat("-", 136))
+		fmt.Printf("%s\r\n", strings.Repeat("-", 155))
 	}
 }
 
 // ParseResults accepts the stdout from the execution of the benchmark. It also needs
 // The NetPerfConfig to determine aspects of the workload the user provided.
 // It will return a NetPerfResults struct or error
-func ParseResults(stdout *bytes.Buffer) (float64, error) {
+func ParseResults(stdout *bytes.Buffer, nc Config) (float64, error) {
 	d := NetReg.FindStringSubmatch(stdout.String())
-	if len(d) < 5 {
-		return 0, fmt.Errorf("❌ Unable to process results")
-	}
 	val := ""
-	if len(d[len(d)-1]) > 0 {
-		val = d[len(d)-1]
+	if strings.Contains(nc.Profile, "UDP_STREAM") {
+		d = NetUDPReg.FindStringSubmatch(stdout.String())
+		if len(d) == 0 {
+			return 0, fmt.Errorf("❌ Unable to process results")
+		}
+		val = d[1]
 	} else {
-		val = d[len(d)-2]
+		if len(d) < 5 {
+			return 0, fmt.Errorf("❌ Unable to process results")
+		}
+		if len(d[len(d)-1]) > 0 {
+			val = d[len(d)-1]
+		} else {
+			val = d[len(d)-2]
+		}
 	}
 	sample, err := strconv.ParseFloat(val, 64)
 	if err != nil {


### PR DESCRIPTION
- added to the SUT function to deploy hostNetwork
- added initial work for pass/fail criteria

pass/fail is currently only for tcp_stream, and we must have hostNetwork data to compare the podNetwork to.

Signed-off-by: Joe Talerico (rook) <joe.talerico@gmail.com>