### PR TITLE
Change to omni output to include latency

### DIFF
--- a/netperf.go
+++ b/netperf.go
@@ -99,7 +99,8 @@ func main() {
 						log.Error(err)
 						os.Exit(1)
 					}
-					npr.Summary = append(npr.Summary, nr)
+					npr.ThroughputSummary = append(npr.ThroughputSummary, nr.Throughput)
+					npr.LatencySummary = append(npr.LatencySummary, nr.Latency99ptile)
 				}
 				sr.Results = append(sr.Results, npr)
 			}
@@ -118,7 +119,8 @@ func main() {
 					log.Error(err)
 					os.Exit(1)
 				}
-				npr.Summary = append(npr.Summary, nr)
+				npr.ThroughputSummary = append(npr.ThroughputSummary, nr.Throughput)
+				npr.LatencySummary = append(npr.LatencySummary, nr.Latency99ptile)
 			}
 			sr.Results = append(sr.Results, npr)
 		} else {
@@ -139,13 +141,15 @@ func main() {
 					log.Error(err)
 					os.Exit(1)
 				}
-				npr.Summary = append(npr.Summary, nr)
+				npr.ThroughputSummary = append(npr.ThroughputSummary, nr.Throughput)
+				npr.LatencySummary = append(npr.LatencySummary, nr.Latency99ptile)
 			}
 			sr.Results = append(sr.Results, npr)
 		}
 	}
 	netperf.ShowStreamResult(sr)
 	netperf.ShowRRResult(sr)
+	netperf.ShowLatencyResult(sr)
 	err = netperf.WriteCSVResult(sr)
 	if err != nil {
 		log.Error(err)

--- a/netperf.yml
+++ b/netperf.yml
@@ -2,30 +2,30 @@
 TCPStream:
    profile: "TCP_STREAM"
    duration: 10
-   samples: 1
-   messagesize: 16384
+   samples: 3
+   messagesize: 1024
 
 UDPStream:
    profile: "UDP_STREAM"
    duration: 10
-   samples: 1
-   messagesize: 16384
+   samples: 3
+   messagesize: 1024
 
 CRR:
    profile: "TCP_CRR"
    duration: 10
-   samples: 1
-   messagesize: 16384
+   samples: 3
+   messagesize: 1024
 
 CRRService:
    profile: "TCP_CRR"
    duration: 10
-   samples: 1
-   messagesize: 16384
+   samples: 3
+   messagesize: 1024
    service: True
 
 RR:
    profile: "TCP_RR"
    duration: 10
-   samples: 1
-   messagesize: 16384
+   samples: 3
+   messagesize: 1024

--- a/netperf/archive.go
+++ b/netperf/archive.go
@@ -34,7 +34,6 @@ func Connect(es elasticParams) (*elasticsearch.Client, error) {
 }
 
 // WriteCSVResult will write the throughput result to the local filesystem
-// TODO: Capture latency results
 func WriteCSVResult(r ScenarioResults) error {
 	fp, err := os.Create(fmt.Sprintf("result-%d.csv", time.Now().Unix()))
 	defer fp.Close()
@@ -43,13 +42,31 @@ func WriteCSVResult(r ScenarioResults) error {
 	}
 	archive := csv.NewWriter(fp)
 	defer archive.Flush()
-	data := []string{"Profile", "Same node", "Host Network", "Service", "Duration", "# of Samples", "Avg Throughput", "Metric"}
+	data := []string{"Profile",
+		"Same node",
+		"Host Network",
+		"Service", "Duration",
+		"# of Samples",
+		"Avg Throughput",
+		"Throughput Metric",
+		"99%tile Observed Latency",
+		"Latency Metric"}
 	if err := archive.Write(data); err != nil {
 		return fmt.Errorf("Failed to write archive to file")
 	}
 	for _, row := range r.Results {
-		avg, _ := average(row.Summary)
-		data := []string{row.Profile, fmt.Sprint(row.SameNode), fmt.Sprint(row.HostNetwork), fmt.Sprint(row.Service), strconv.Itoa(row.Duration), strconv.Itoa(row.Samples), fmt.Sprintf("%f", avg), row.Metric}
+		avg, _ := average(row.ThroughputSummary)
+		lavg, _ := average(row.LatencySummary)
+		data := []string{row.Profile,
+			fmt.Sprint(row.SameNode),
+			fmt.Sprint(row.HostNetwork),
+			fmt.Sprint(row.Service),
+			strconv.Itoa(row.Duration),
+			strconv.Itoa(row.Samples),
+			fmt.Sprintf("%f", avg),
+			row.Metric,
+			fmt.Sprint(lavg),
+			"usec"}
 		if err := archive.Write(data); err != nil {
 			return fmt.Errorf("Failed to write archive to file")
 		}

--- a/netperf/kubernetes.go
+++ b/netperf/kubernetes.go
@@ -45,7 +45,7 @@ func GetZone(c *kubernetes.Clientset) (string, error) {
 	}
 	for _, l := range n.Items {
 		if len(l.GetLabels()["topology.kubernetes.io/zone"]) < 1 {
-			return "", fmt.Errorf("⚠️ No zone label")
+			return "", fmt.Errorf("⚠️  No zone label")
 		}
 		if _, ok := zones[l.GetLabels()["topology.kubernetes.io/zone"]]; ok {
 			zone = l.GetLabels()["topology.kubernetes.io/zone"]
@@ -57,7 +57,7 @@ func GetZone(c *kubernetes.Clientset) (string, error) {
 	}
 	// No zone had > 1, use the last zone.
 	if zone == "" {
-		fmt.Println("⚠️ Single node per zone")
+		fmt.Println("⚠️  Single node per zone")
 		zone = lz
 	}
 	return zone, nil
@@ -139,7 +139,7 @@ func GetPods(c *kubernetes.Clientset, dp DeploymentParams) (apiv1.PodList, error
 func CreateService(sp ServiceParams, client *kubernetes.Clientset) (*apiv1.Service, error) {
 	s, err := client.CoreV1().Services(sp.Namespace).Get(context.TODO(), sp.Name, metav1.GetOptions{})
 	if err == nil {
-		fmt.Println("♻️ Using existing Service")
+		fmt.Println("♻️  Using existing Service")
 		return s, nil
 	}
 	fmt.Printf("🚀 Creating service for %s in %s\n", sp.Name, sp.Namespace)


### PR DESCRIPTION
Instead of using regex to capture results, switch to the omni output. Moving to the omni output we can capture more results such as the latency values seen from netperf.

Todo : write latency values to dedicated csv

Signed-off-by: Joe Talerico (rook) <joe.talerico@gmail.com>