### PR TITLE
Multiprocess Netperf

### DIFF
--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -1,13 +1,16 @@
-FROM registry.access.redhat.com/ubi8:8.6
+FROM registry.access.redhat.com/ubi9:latest
 
 COPY appstream.repo /etc/yum.repos.d/centos8-appstream.repo
 RUN dnf install -y --nodocs make automake --enablerepo=centos9 --allowerasing
-RUN dnf install -y --nodocs gcc git --enablerepo=centos9 --allowerasing
+RUN dnf install -y --nodocs gcc git bc lksctp-tools-devel --enablerepo=*
 RUN git clone https://github.com/HewlettPackard/netperf
 WORKDIR netperf
 RUN git reset --hard 3bc455b23f901dae377ca0a558e1e32aa56b31c4 
+RUN curl -O https://gist.githubusercontent.com/jtaleric/c367e06b9e3f782c042667577aa1f705/raw/71e9ed086d4c2aef24c7fce7f3d9b594873e621c/netperf.diff
+RUN git apply netperf.diff
 RUN ./autogen.sh
-RUN ./configure --enable-demo && make && make install
+RUN ./configure --enable-sctp=yes --enable-demo=yes && make && make install
 WORKDIR ../
 RUN rm -rf netperf/
-RUN dnf remove gcc make automake git -y
+RUN curl -O https://raw.githubusercontent.com/jtaleric/tinker/main/networking/super-netperf
+RUN chmod +x super-netperf

--- a/netperf.go
+++ b/netperf.go
@@ -225,6 +225,13 @@ func main() {
 		log.Error(err)
 		os.Exit(1)
 	}
+	if pavail {
+		err = netperf.WritePromCSVResult(sr)
+		if err != nil {
+			log.Error(err)
+			os.Exit(1)
+		}
+	}
 	// Initially we are just checking against TCP_STREAM results.
 	if netperf.CheckHostResults(sr) {
 		diff, err := netperf.TCPThroughputDiff(sr)

--- a/netperf.yml
+++ b/netperf.yml
@@ -1,29 +1,34 @@
 ---
 TCPStream:
+   parallelism: 1
    profile: "TCP_STREAM"
    duration: 10
    samples: 3
    messagesize: 1024
 
 TCPStream2:
+   parallelism: 1
    profile: "TCP_STREAM"
    duration: 10
    samples: 3
    messagesize: 8192
 
 UDPStream:
+   parallelism: 1
    profile: "UDP_STREAM"
    duration: 10
    samples: 3
    messagesize: 1024
 
 CRR:
+   parallelism: 1
    profile: "TCP_CRR"
    duration: 10
    samples: 3
    messagesize: 1024
 
 CRRService:
+   parallelism: 1
    profile: "TCP_CRR"
    duration: 10
    samples: 3
@@ -31,6 +36,7 @@ CRRService:
    service: True
 
 RR:
+   parallelism: 1
    profile: "TCP_RR"
    duration: 10
    samples: 3

--- a/netperf/result.go
+++ b/netperf/result.go
@@ -96,48 +96,48 @@ func calDiff(a float64, b float64) float64 {
 
 // ShowPodCPU accepts ScenarioResults and presents to the user via stdout the PodCPU info
 func ShowPodCPU(s ScenarioResults) {
-	fmt.Printf("%s Pod CPU Utilization %s\r\n", strings.Repeat("-", 73), strings.Repeat("-", 73))
-	fmt.Printf("%-18s | %-15s | %-15s | %-15s | %-15s | %-15s | %-25s | %-15s \r\n", "Role", "Scenario", "Host Network", "Service", "Message Size", "Same node", "Pod", "Utilization")
-	fmt.Printf("%s\r\n", strings.Repeat("-", 166))
+	fmt.Printf("%s Pod CPU Utilization %s\r\n", strings.Repeat("-", 78), strings.Repeat("-", 78))
+	fmt.Printf("%-18s | %-15s |  %-15s | %-15s | %-15s | %-15s | %-15s | %-25s | %-15s \r\n", "Role", "Scenario", "Parallelism", "Host Network", "Service", "Message Size", "Same node", "Pod", "Utilization")
+	fmt.Printf("%s\r\n", strings.Repeat("-", 176))
 	for _, r := range s.Results {
 		for _, pod := range r.ClientPodCPU.Results {
-			fmt.Printf("📊 %-15s | %-15s | %-15t | %-15t | %-15d | %-15t | %-25s | %-15f \r\n", "Client", r.Profile, r.HostNetwork, r.Service, r.MessageSize, r.SameNode, fmt.Sprintf("%.20s", pod.Name), pod.Value)
+			fmt.Printf("📊 %-15s | %-15s |  %-15d | %-15t | %-15t | %-15d | %-15t | %-25s | %-15f \r\n", "Client", r.Profile, r.Parallelism, r.HostNetwork, r.Service, r.MessageSize, r.SameNode, fmt.Sprintf("%.20s", pod.Name), pod.Value)
 		}
-		fmt.Printf("%s\r\n", strings.Repeat("-", 166))
+		fmt.Printf("%s\r\n", strings.Repeat("-", 176))
 		for _, pod := range r.ServerPodCPU.Results {
-			fmt.Printf("📊 %-15s | %-15s | %-15t | %-15t | %-15d | %-15t | %-25s | %-15f \r\n", "Server", r.Profile, r.HostNetwork, r.Service, r.MessageSize, r.SameNode, fmt.Sprintf("%.20s", pod.Name), pod.Value)
+			fmt.Printf("📊 %-15s | %-15s |  %-15d | %-15t | %-15t | %-15d | %-15t | %-25s | %-15f \r\n", "Server", r.Profile, r.Parallelism, r.HostNetwork, r.Service, r.MessageSize, r.SameNode, fmt.Sprintf("%.20s", pod.Name), pod.Value)
 		}
-		fmt.Printf("%s\r\n", strings.Repeat("-", 166))
+		fmt.Printf("%s\r\n", strings.Repeat("-", 176))
 	}
 }
 
 // ShowNodeCPU accepts ScenarioResults and presents to the user via stdout the NodeCPU info
 func ShowNodeCPU(s ScenarioResults) {
-	fmt.Printf("%s Node CPU Utilization %s\r\n", strings.Repeat("-", 111), strings.Repeat("-", 111))
-	fmt.Printf("%-18s | %-15s | %-15s | %-15s | %-15s | %-15s | %-15s | %-15s | %-15s | %-15s | %-15s | %-15s | %-15s | %-15s\r\n", "Role", "Scenario", "Host Network", "Service", "Message Size", "Same node", "Idle CPU", "User CPU", "System CPU", "Steal CPU", "IOWait CPU", "Nice CPU", "SoftIRQ CPU", "IRQ CPU")
-	fmt.Printf("%s\r\n", strings.Repeat("-", 245))
+	fmt.Printf("%s Node CPU Utilization %s\r\n", strings.Repeat("-", 115), strings.Repeat("-", 115))
+	fmt.Printf("%-18s | %-15s | %-15s |  %-15s | %-15s | %-15s | %-15s | %-15s | %-15s | %-15s | %-15s | %-15s | %-15s | %-15s | %-15s\r\n", "Role", "Scenario", "Parallelism", "Host Network", "Service", "Message Size", "Same node", "Idle CPU", "User CPU", "System CPU", "Steal CPU", "IOWait CPU", "Nice CPU", "SoftIRQ CPU", "IRQ CPU")
+	fmt.Printf("%s\r\n", strings.Repeat("-", 255))
 	for _, r := range s.Results {
 		ccpu := r.ClientMetrics
 		scpu := r.ServerMetrics
-		fmt.Printf("📊 %-15s | %-15s | %-15t | %-15t | %-15d | %-15t | %-15f | %-15f | %-15f | %-15f | %-15f | %-15f | %-15f | %-15f\r\n", "Client", r.Profile, r.HostNetwork, r.Service, r.MessageSize, r.SameNode, ccpu.Idle, ccpu.User, ccpu.System, ccpu.Steal, ccpu.Iowait, ccpu.Nice, ccpu.Softirq, ccpu.Irq)
-		fmt.Printf("📊 %-15s | %-15s | %-15t | %-15t | %-15d | %-15t | %-15f | %-15f | %-15f | %-15f | %-15f | %-15f | %-15f | %-15f\r\n", "Server", r.Profile, r.HostNetwork, r.Service, r.MessageSize, r.SameNode, scpu.Idle, scpu.User, scpu.System, scpu.Steal, ccpu.Iowait, ccpu.Nice, ccpu.Softirq, ccpu.Irq)
+		fmt.Printf("📊 %-15s | %-15s | %-15d | %-15t | %-15t | %-15d | %-15t | %-15f | %-15f | %-15f | %-15f | %-15f | %-15f | %-15f | %-15f\r\n", "Client", r.Profile, r.Parallelism, r.HostNetwork, r.Service, r.MessageSize, r.SameNode, ccpu.Idle, ccpu.User, ccpu.System, ccpu.Steal, ccpu.Iowait, ccpu.Nice, ccpu.Softirq, ccpu.Irq)
+		fmt.Printf("📊 %-15s | %-15s | %-15d | %-15t | %-15t | %-15d | %-15t | %-15f | %-15f | %-15f | %-15f | %-15f | %-15f | %-15f | %-15f\r\n", "Server", r.Profile, r.Parallelism, r.HostNetwork, r.Service, r.MessageSize, r.SameNode, scpu.Idle, scpu.User, scpu.System, scpu.Steal, ccpu.Iowait, ccpu.Nice, ccpu.Softirq, ccpu.Irq)
 	}
-	fmt.Printf("%s\r\n", strings.Repeat("-", 245))
+	fmt.Printf("%s\r\n", strings.Repeat("-", 255))
 }
 
 // ShowStreamResult accepts NetPerfResults to display to the user via stdout
 func ShowStreamResult(s ScenarioResults) {
 	if checkResults(s, "STREAM") {
-		fmt.Printf("%s Stream Results %s\r\n", strings.Repeat("-", 69), strings.Repeat("-", 69))
-		fmt.Printf("%-18s | %-15s |%-15s | %-15s | %-15s | %-15s | %-15s | %-15s\r\n", "Scenario", "Host Network", "Service", "Message Size", "Same node", "Duration", "Samples", "Avg value")
-		fmt.Printf("%s\r\n", strings.Repeat("-", 155))
+		fmt.Printf("%s Stream Results %s\r\n", strings.Repeat("-", 79), strings.Repeat("-", 79))
+		fmt.Printf("%-18s | %-15s | %-15s | %-15s | %-15s | %-15s | %-15s | %-15s | %-15s\r\n", "Scenario", "Parallelism", "Host Network", "Service", "Message Size", "Same node", "Duration", "Samples", "Avg value")
+		fmt.Printf("%s\r\n", strings.Repeat("-", 175))
 		for _, r := range s.Results {
 			if strings.Contains(r.Profile, "STREAM") {
 				avg, _ := average(r.ThroughputSummary)
-				fmt.Printf("📊 %-15s | %-15t |%-15t | %-15d | %-15t | %-15d | %-15d | %-15f (%s) \r\n", r.Profile, r.HostNetwork, r.Service, r.MessageSize, r.SameNode, r.Duration, r.Samples, avg, r.Metric)
+				fmt.Printf("📊 %-15s | %-15d | %-15t | %-15t | %-15d | %-15t | %-15d | %-15d | %-15f (%s) \r\n", r.Profile, r.Parallelism, r.HostNetwork, r.Service, r.MessageSize, r.SameNode, r.Duration, r.Samples, avg, r.Metric)
 			}
 		}
-		fmt.Printf("%s\r\n", strings.Repeat("-", 155))
+		fmt.Printf("%s\r\n", strings.Repeat("-", 175))
 
 	}
 }
@@ -145,28 +145,28 @@ func ShowStreamResult(s ScenarioResults) {
 // ShowLatencyResult accepts NetPerfResults to display to the user via stdout
 func ShowLatencyResult(s ScenarioResults) {
 	if checkResults(s, "STREAM") {
-		fmt.Printf("%s Stream Latency Results %s\r\n", strings.Repeat("-", 65), strings.Repeat("-", 65))
-		fmt.Printf("%-18s | %-15s |%-15s | %-15s | %-15s | %-15s | %-15s | %-15s\r\n", "Scenario", "Host Network", "Service", "Message Size", "Same node", "Duration", "Samples", "99%tile value")
-		fmt.Printf("%s\r\n", strings.Repeat("-", 155))
+		fmt.Printf("%s Stream Latency Results %s\r\n", strings.Repeat("-", 75), strings.Repeat("-", 75))
+		fmt.Printf("%-18s | %-15s | %-15s | %-15s | %-15s | %-15s | %-15s | %-15s | %-15s\r\n", "Scenario", "Parallelism", "Host Network", "Service", "Message Size", "Same node", "Duration", "Samples", "99%tile value")
+		fmt.Printf("%s\r\n", strings.Repeat("-", 175))
 		for _, r := range s.Results {
 			if strings.Contains(r.Profile, "STREAM") {
 				avg, _ := average(r.LatencySummary)
-				fmt.Printf("📊 %-15s | %-15t |%-15t | %-15d | %-15t | %-15d | %-15d | %-15f (%s) \r\n", r.Profile, r.HostNetwork, r.Service, r.MessageSize, r.SameNode, r.Duration, r.Samples, avg, "usec")
+				fmt.Printf("📊 %-15s | %-15d | %-15t |%-15t | %-15d | %-15t | %-15d | %-15d | %-15f (%s) \r\n", r.Profile, r.Parallelism, r.HostNetwork, r.Service, r.MessageSize, r.SameNode, r.Duration, r.Samples, avg, "usec")
 			}
 		}
-		fmt.Printf("%s\r\n", strings.Repeat("-", 155))
+		fmt.Printf("%s\r\n", strings.Repeat("-", 175))
 	}
 	if checkResults(s, "RR") {
-		fmt.Printf("%s RR Latency Results %s\r\n", strings.Repeat("-", 66), strings.Repeat("-", 66))
-		fmt.Printf("%-18s | %-15s |%-15s | %-15s | %-15s | %-15s | %-15s | %-15s\r\n", "Scenario", "Host Network", "Service", "Message Size", "Same node", "Duration", "Samples", "99%tile value")
-		fmt.Printf("%s\r\n", strings.Repeat("-", 155))
+		fmt.Printf("%s RR Latency Results %s\r\n", strings.Repeat("-", 76), strings.Repeat("-", 76))
+		fmt.Printf("%-18s | %-15s | %-15s | %-15s | %-15s | %-15s | %-15s | %-15s | %-15s\r\n", "Scenario", "Parallelism", "Host Network", "Service", "Message Size", "Same node", "Duration", "Samples", "99%tile value")
+		fmt.Printf("%s\r\n", strings.Repeat("-", 175))
 		for _, r := range s.Results {
 			if strings.Contains(r.Profile, "RR") {
 				avg, _ := average(r.LatencySummary)
-				fmt.Printf("📊 %-15s | %-15t |%-15t | %-15d | %-15t | %-15d | %-15d | %-15f (%s) \r\n", r.Profile, r.HostNetwork, r.Service, r.MessageSize, r.SameNode, r.Duration, r.Samples, avg, "usec")
+				fmt.Printf("📊 %-15s |  %-15d | %-15t | %-15t | %-15d | %-15t | %-15d | %-15d | %-15f (%s) \r\n", r.Profile, r.Parallelism, r.HostNetwork, r.Service, r.MessageSize, r.SameNode, r.Duration, r.Samples, avg, "usec")
 			}
 		}
-		fmt.Printf("%s\r\n", strings.Repeat("-", 155))
+		fmt.Printf("%s\r\n", strings.Repeat("-", 175))
 	}
 }
 
@@ -175,15 +175,15 @@ func ShowLatencyResult(s ScenarioResults) {
 // TODO: Capture latency values
 func ShowRRResult(s ScenarioResults) {
 	if checkResults(s, "RR") {
-		fmt.Printf("%s RR Results %s\r\n", strings.Repeat("-", 72), strings.Repeat("-", 72))
-		fmt.Printf("%-18s | %-15s |%-15s | %-15s | %-15s | %-15s | %-15s | %-15s\r\n", "Scenario", "Host Network", "Service", "Message Size", "Same node", "Duration", "Samples", "Avg value")
-		fmt.Printf("%s\r\n", strings.Repeat("-", 155))
+		fmt.Printf("%s RR Results %s\r\n", strings.Repeat("-", 82), strings.Repeat("-", 82))
+		fmt.Printf("%-18s | %-15s | %-15s | %-15s | %-15s | %-15s | %-15s | %-15s | %-15s\r\n", "Scenario", "Parallelism", "Host Network", "Service", "Message Size", "Same node", "Duration", "Samples", "Avg value")
+		fmt.Printf("%s\r\n", strings.Repeat("-", 175))
 		for _, r := range s.Results {
 			if strings.Contains(r.Profile, "RR") {
 				avg, _ := average(r.ThroughputSummary)
-				fmt.Printf("📊 %-15s | %-15t |%-15t | %-15d | %-15t | %-15d | %-15d | %-15f (%s) \r\n", r.Profile, r.HostNetwork, r.Service, r.MessageSize, r.SameNode, r.Duration, r.Samples, avg, r.Metric)
+				fmt.Printf("📊 %-15s | %-15d | %-15t | %-15t | %-15d | %-15t | %-15d | %-15d | %-15f (%s) \r\n", r.Profile, r.Parallelism, r.HostNetwork, r.Service, r.MessageSize, r.SameNode, r.Duration, r.Samples, avg, r.Metric)
 			}
 		}
-		fmt.Printf("%s\r\n", strings.Repeat("-", 155))
+		fmt.Printf("%s\r\n", strings.Repeat("-", 175))
 	}
 }

--- a/testing/test-config.yml
+++ b/testing/test-config.yml
@@ -1,5 +1,6 @@
 ---
 TCPStream:
+   parallelism: 1
    profile: "TCP_STREAM"
    duration: 10
    samples: 1


### PR DESCRIPTION
- Update Container file to include super-netperf script
- Update Container file to ubi9
- Update Container build to include sctp for netperf
- Allow the user to have mutliple processes of netperf

Fixes #25

Signed-off-by: Joe Talerico <jtaleric@redhat.com>