### PR TITLE
Moving archive and results out

### DIFF
--- a/pkg/netperf/netperf.go
+++ b/pkg/netperf/netperf.go
@@ -10,19 +10,12 @@ import (
 
 	"github.com/jtaleric/k8s-netperf/pkg/config"
 	log "github.com/jtaleric/k8s-netperf/pkg/logging"
+	"github.com/jtaleric/k8s-netperf/pkg/sample"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
 )
-
-// Sample describes the values we will return with each execution.
-type Sample struct {
-	Latency        float64
-	Latency99ptile float64
-	Throughput     float64
-	Metric         string
-}
 
 // ServerCtlPort control port for the service
 const ServerCtlPort = 12865
@@ -104,8 +97,8 @@ func Run(c *kubernetes.Clientset, rc rest.Config, nc config.Config, client apiv1
 // ParseResults accepts the stdout from the execution of the benchmark. It also needs
 // The NetPerfConfig to determine aspects of the workload the user provided.
 // It will return a Sample struct or error
-func ParseResults(stdout *bytes.Buffer, nc config.Config) (Sample, error) {
-	sample := Sample{}
+func ParseResults(stdout *bytes.Buffer, nc config.Config) (sample.Sample, error) {
+	sample := sample.Sample{}
 	for _, line := range strings.Split(stdout.String(), "\n") {
 		l := strings.Split(line, "=")
 		if len(l) < 2 {

--- a/pkg/results/result.go
+++ b/pkg/results/result.go
@@ -1,4 +1,4 @@
-package netperf
+package result
 
 import (
 	"fmt"
@@ -7,6 +7,7 @@ import (
 
 	"github.com/jtaleric/k8s-netperf/pkg/config"
 	"github.com/jtaleric/k8s-netperf/pkg/metrics"
+	"github.com/jtaleric/k8s-netperf/pkg/sample"
 	stats "github.com/montanaflynn/stats"
 )
 
@@ -18,7 +19,7 @@ type Data struct {
 	HostNetwork       bool
 	ClientNodeInfo    metrics.NodeInfo
 	ServerNodeInfo    metrics.NodeInfo
-	Sample            Sample
+	Sample            sample.Sample
 	StartTime         time.Time
 	EndTime           time.Time
 	Service           bool
@@ -46,13 +47,13 @@ type Metadata struct {
 	MTU        int    `json:"mtu"`
 }
 
-// average accepts array of floats to calculate average
-func average(vals []float64) (float64, error) {
+// Average accepts array of floats to calculate average
+func Average(vals []float64) (float64, error) {
 	return stats.Median(vals)
 }
 
-// percentile accepts array of floats and the desired %tile to calculate
-func percentile(vals []float64, ptile float64) (float64, error) {
+// Percentile accepts array of floats and the desired %tile to calculate
+func Percentile(vals []float64, ptile float64) (float64, error) {
 	return stats.Percentile(vals, ptile)
 }
 
@@ -88,11 +89,11 @@ func TCPThroughputDiff(s ScenarioResults) (float64, error) {
 		if !s.Results[t].Service {
 			if s.Results[t].HostNetwork {
 				if s.Results[t].Profile == "TCP_STREAM" {
-					hostPerf, _ = average(s.Results[t].ThroughputSummary)
+					hostPerf, _ = Average(s.Results[t].ThroughputSummary)
 				}
 			} else {
 				if s.Results[t].Profile == "TCP_STREAM" {
-					podPerf, _ = average(s.Results[t].ThroughputSummary)
+					podPerf, _ = Average(s.Results[t].ThroughputSummary)
 				}
 			}
 		}
@@ -145,7 +146,7 @@ func ShowStreamResult(s ScenarioResults) {
 		fmt.Printf("%s\r\n", strings.Repeat("-", 175))
 		for _, r := range s.Results {
 			if strings.Contains(r.Profile, "STREAM") {
-				avg, _ := average(r.ThroughputSummary)
+				avg, _ := Average(r.ThroughputSummary)
 				fmt.Printf("📊 %-15s | %-15d | %-15t | %-15t | %-15d | %-15t | %-15d | %-15d | %-15f (%s) \r\n", r.Profile, r.Parallelism, r.HostNetwork, r.Service, r.MessageSize, r.SameNode, r.Duration, r.Samples, avg, r.Metric)
 			}
 		}
@@ -162,7 +163,7 @@ func ShowLatencyResult(s ScenarioResults) {
 		fmt.Printf("%s\r\n", strings.Repeat("-", 175))
 		for _, r := range s.Results {
 			if strings.Contains(r.Profile, "STREAM") {
-				avg, _ := average(r.LatencySummary)
+				avg, _ := Average(r.LatencySummary)
 				fmt.Printf("📊 %-15s | %-15d | %-15t |%-15t | %-15d | %-15t | %-15d | %-15d | %-15f (%s) \r\n", r.Profile, r.Parallelism, r.HostNetwork, r.Service, r.MessageSize, r.SameNode, r.Duration, r.Samples, avg, "usec")
 			}
 		}
@@ -174,7 +175,7 @@ func ShowLatencyResult(s ScenarioResults) {
 		fmt.Printf("%s\r\n", strings.Repeat("-", 175))
 		for _, r := range s.Results {
 			if strings.Contains(r.Profile, "RR") {
-				avg, _ := average(r.LatencySummary)
+				avg, _ := Average(r.LatencySummary)
 				fmt.Printf("📊 %-15s |  %-15d | %-15t | %-15t | %-15d | %-15t | %-15d | %-15d | %-15f (%s) \r\n", r.Profile, r.Parallelism, r.HostNetwork, r.Service, r.MessageSize, r.SameNode, r.Duration, r.Samples, avg, "usec")
 			}
 		}
@@ -192,7 +193,7 @@ func ShowRRResult(s ScenarioResults) {
 		fmt.Printf("%s\r\n", strings.Repeat("-", 175))
 		for _, r := range s.Results {
 			if strings.Contains(r.Profile, "RR") {
-				avg, _ := average(r.ThroughputSummary)
+				avg, _ := Average(r.ThroughputSummary)
 				fmt.Printf("📊 %-15s | %-15d | %-15t | %-15t | %-15d | %-15t | %-15d | %-15d | %-15f (%s) \r\n", r.Profile, r.Parallelism, r.HostNetwork, r.Service, r.MessageSize, r.SameNode, r.Duration, r.Samples, avg, r.Metric)
 			}
 		}

--- a/pkg/sample/types.go
+++ b/pkg/sample/types.go
@@ -1,0 +1,9 @@
+package sample
+
+// Sample describes the values we will return with each execution.
+type Sample struct {
+	Latency        float64
+	Latency99ptile float64
+	Throughput     float64
+	Metric         string
+}


### PR DESCRIPTION
Making it so archive, results and samples can be used with different load generators, not just netperf