### PR TITLE
Adding iperf3 workload driver

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,6 +10,7 @@ import (
 	log "github.com/jtaleric/k8s-netperf/pkg/logging"
 	"github.com/jtaleric/k8s-netperf/pkg/metrics"
 	"gopkg.in/yaml.v2"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
 
@@ -21,6 +22,7 @@ type Config struct {
 	Samples     int    `yaml:"samples,omitempty"`
 	MessageSize int    `yaml:"messagesize,omitempty"`
 	Service     bool   `default:"false" yaml:"service,omitempty"`
+	Metric      string
 }
 
 // PerfScenarios describes the different scenarios
@@ -35,8 +37,10 @@ type PerfScenarios struct {
 	ClientAcross   apiv1.PodList
 	ClientHost     apiv1.PodList
 	ServerHost     apiv1.PodList
-	Service        *apiv1.Service
+	NetperfService *apiv1.Service
+	IperfService   *apiv1.Service
 	RestConfig     rest.Config
+	ClientSet      *kubernetes.Clientset
 }
 
 // Tests we will support in k8s-netperf
@@ -87,6 +91,6 @@ func ParseConf(fn string) ([]Config, error) {
 }
 
 // Show Display the netperf config
-func Show(c Config) {
-	log.Infof("🗒️  Running netperf %s (service %t) for %ds\n", c.Profile, c.Service, c.Duration)
+func Show(c Config, driver string) {
+	log.Infof("🗒️  Running %s %s (service %t) for %ds\n", driver, c.Profile, c.Service, c.Duration)
 }

--- a/pkg/iperf/iperf.go
+++ b/pkg/iperf/iperf.go
@@ -1,0 +1,146 @@
+package iperf
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"encoding/json"
+
+	apiv1 "k8s.io/api/core/v1"
+
+	"github.com/jtaleric/k8s-netperf/pkg/config"
+	log "github.com/jtaleric/k8s-netperf/pkg/logging"
+	"github.com/jtaleric/k8s-netperf/pkg/sample"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+type Result struct {
+	Data struct {
+		TCPStream struct {
+			Rate float32 `json:"bits_per_second"`
+		} `json:"sum_received"`
+		UDPStream struct {
+			Rate        float32 `json:"bits_per_second"`
+			LossPercent float32 `json:"lost_percent"`
+		} `json:"sum"`
+	} `json:"end"`
+}
+
+const workload = "iperf3"
+
+// ServerDataPort data port for the service
+const ServerDataPort = 43433
+
+// ServerCtlPort control port for the service
+const ServerCtlPort = 22865
+
+// TestSupported Determine if the test is supproted for driver
+func TestSupported(test string) bool {
+	return strings.Contains(test, "STREAM")
+}
+
+// Run will invoke iperf3 in a client container
+func Run(c *kubernetes.Clientset, rc rest.Config, nc config.Config, client apiv1.PodList, serverIP string) (bytes.Buffer, error) {
+	var stdout, stderr bytes.Buffer
+	pod := client.Items[0]
+	log.Debugf("🔥 Client (%s,%s) starting iperf3 against server : %s\n", pod.Name, pod.Status.PodIP, serverIP)
+	config.Show(nc, workload)
+	tcp := true
+	if !strings.Contains(nc.Profile, "STREAM") {
+		return bytes.Buffer{}, fmt.Errorf("Unable to run iperf3 with non-stream tests")
+	}
+	if strings.Contains(nc.Profile, "UDP") {
+		tcp = false
+	}
+	cmd := []string{}
+	if nc.Service {
+		if tcp {
+			cmd = []string{"iperf3", "-P", "1", "-c",
+				serverIP, "-J", "-t",
+				fmt.Sprintf("%d", nc.Duration),
+				"-l", fmt.Sprintf("%d", nc.MessageSize),
+				"-p", fmt.Sprintf("%d", ServerCtlPort),
+			}
+		} else {
+			cmd = []string{"iperf3", "-P", "1", "-c",
+				serverIP, "-t",
+				fmt.Sprintf("%d", nc.Duration), "-u", "-J",
+				"-l", fmt.Sprintf("%d", nc.MessageSize),
+				"-p", fmt.Sprintf("%d", ServerCtlPort),
+				"-b", "0",
+			}
+		}
+	} else {
+		if tcp {
+			cmd = []string{"iperf3", "-J", "-P", strconv.Itoa(nc.Parallelism), "-c",
+				serverIP, "-t",
+				fmt.Sprintf("%d", nc.Duration),
+				"-l", fmt.Sprintf("%d", nc.MessageSize),
+				"-p", fmt.Sprintf("%d", ServerCtlPort),
+			}
+		} else {
+			cmd = []string{"iperf3", "-J", "-P", strconv.Itoa(nc.Parallelism), "-c",
+				serverIP, "-t",
+				fmt.Sprintf("%d", nc.Duration), "-u",
+				"-l", fmt.Sprintf("%d", nc.MessageSize),
+				"-p", fmt.Sprintf("%d", ServerCtlPort),
+				"-b", "0",
+			}
+		}
+	}
+	log.Debug(cmd)
+	req := c.CoreV1().RESTClient().
+		Post().
+		Namespace(pod.Namespace).
+		Resource("pods").
+		Name(pod.Name).
+		SubResource("exec").
+		VersionedParams(&apiv1.PodExecOptions{
+			Container: pod.Spec.Containers[0].Name,
+			Command:   cmd,
+			Stdin:     false,
+			Stdout:    true,
+			Stderr:    true,
+			TTY:       true,
+		}, scheme.ParameterCodec)
+	exec, err := remotecommand.NewSPDYExecutor(&rc, "POST", req.URL())
+	if err != nil {
+		return stdout, err
+	}
+	// Connect this process' std{in,out,err} to the remote shell process.
+	err = exec.Stream(remotecommand.StreamOptions{
+		Stdin:  nil,
+		Stdout: &stdout,
+		Stderr: &stderr,
+	})
+	if err != nil {
+		return stdout, err
+	}
+	log.Debug(strings.TrimSpace(stdout.String()))
+	return stdout, nil
+}
+
+// ParseResults accepts the stdout from the execution of the benchmark. It also needs
+// The NetConfig to determine aspects of the workload the user provided.
+// It will return a Sample struct or error
+func ParseResults(stdout *bytes.Buffer) (sample.Sample, error) {
+	sample := sample.Sample{}
+	sample.Driver = workload
+	result := Result{}
+	sample.Metric = "Mb/s"
+	json.NewDecoder(stdout).Decode(&result)
+	if result.Data.TCPStream.Rate > 0 {
+		sample.Throughput = float64(result.Data.TCPStream.Rate) / 1000000
+
+	} else {
+		sample.Throughput = float64(result.Data.UDPStream.Rate) / 1000000
+	}
+	log.Debugf("Storing %s sample throughput:  %f", sample.Driver, sample.Throughput)
+
+	return sample, nil
+}

--- a/pkg/results/result.go
+++ b/pkg/results/result.go
@@ -1,22 +1,24 @@
 package result
 
 import (
-	"os"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/jtaleric/k8s-netperf/pkg/config"
+	"github.com/jtaleric/k8s-netperf/pkg/logging"
 	"github.com/jtaleric/k8s-netperf/pkg/metrics"
 	"github.com/jtaleric/k8s-netperf/pkg/sample"
-	"github.com/olekukonko/tablewriter"
 	stats "github.com/montanaflynn/stats"
+	"github.com/olekukonko/tablewriter"
 )
 
 // Data describes the result data
 type Data struct {
 	config.Config
+	Driver            string
 	Metric            string
 	SameNode          bool
 	HostNetwork       bool
@@ -105,7 +107,7 @@ func TCPThroughputDiff(s ScenarioResults) (float64, error) {
 }
 
 // Method to init common table structure.
-func initTable(header []string) (*tablewriter.Table) {
+func initTable(header []string) *tablewriter.Table {
 	// Create a new table writer with the appropriate header and alignment options
 	table := tablewriter.NewWriter(os.Stdout)
 	// Add a header to the table
@@ -123,30 +125,36 @@ func calDiff(a float64, b float64) float64 {
 
 // ShowPodCPU accepts ScenarioResults and presents to the user via stdout the PodCPU info
 func ShowPodCPU(s ScenarioResults) {
-	table := initTable([]string{"Result Type", "Role", "Scenario", "Parallelism", "Host Network", "Service", "Message Size", "Same node", "Pod", "Utilization"})
-    for _, r := range s.Results {
-        for _, pod := range r.ClientPodCPU.Results {
-            table.Append([]string{"Pod CPU Utilization", "Client", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%t", r.SameNode), fmt.Sprintf("%.20s", pod.Name), fmt.Sprintf("%f", pod.Value)})
-        }
-        for _, pod := range r.ServerPodCPU.Results {
-            table.Append([]string{"Pod CPU Utilization", "Server", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%t", r.SameNode), fmt.Sprintf("%.20s", pod.Name), fmt.Sprintf("%f", pod.Value)})
-        }
-    }
+	table := initTable([]string{"Result Type", "Driver", "Role", "Scenario", "Parallelism", "Host Network", "Service", "Message Size", "Same node", "Pod", "Utilization"})
+	for _, r := range s.Results {
+		for _, pod := range r.ClientPodCPU.Results {
+			table.Append([]string{"Pod CPU Utilization", r.Driver, "Client", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%t", r.SameNode), fmt.Sprintf("%.20s", pod.Name), fmt.Sprintf("%f", pod.Value)})
+		}
+		for _, pod := range r.ServerPodCPU.Results {
+			table.Append([]string{"Pod CPU Utilization", r.Driver, "Server", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%t", r.SameNode), fmt.Sprintf("%.20s", pod.Name), fmt.Sprintf("%f", pod.Value)})
+		}
+	}
 	table.Render()
 }
 
 // ShowNodeCPU accepts ScenarioResults and presents to the user via stdout the NodeCPU info
 func ShowNodeCPU(s ScenarioResults) {
-	table := initTable([]string{"Result Type", "Role", "Scenario", "Parallelism", "Host Network", "Service", "Message Size", "Same node", "Idle CPU", "User CPU", "System CPU", "Steal CPU", "IOWait CPU", "Nice CPU", "SoftIRQ CPU", "IRQ CPU"})
+	table := initTable([]string{"Result Type", "Driver", "Role", "Scenario", "Parallelism", "Host Network", "Service", "Message Size", "Same node", "Idle CPU", "User CPU", "System CPU", "Steal CPU", "IOWait CPU", "Nice CPU", "SoftIRQ CPU", "IRQ CPU"})
 	for _, r := range s.Results {
+		// Skip RR/CRR iperf3 Results
+		if strings.Contains(r.Profile, "RR") {
+			if r.Driver != "netperf" {
+				continue
+			}
+		}
 		ccpu := r.ClientMetrics
 		scpu := r.ServerMetrics
 		table.Append([]string{
-			"Node CPU Utilization", "Client", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%t", r.SameNode),
+			"Node CPU Utilization", r.Driver, "Client", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%t", r.SameNode),
 			fmt.Sprintf("%f", ccpu.Idle), fmt.Sprintf("%f", ccpu.User), fmt.Sprintf("%f", ccpu.System), fmt.Sprintf("%f", ccpu.Steal), fmt.Sprintf("%f", ccpu.Iowait), fmt.Sprintf("%f", ccpu.Nice), fmt.Sprintf("%f", ccpu.Softirq), fmt.Sprintf("%f", ccpu.Irq),
 		})
 		table.Append([]string{
-			"Node CPU Utilization", "Server", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%t", r.SameNode),
+			"Node CPU Utilization", r.Driver, "Server", r.Profile, fmt.Sprintf("%d", r.Parallelism), fmt.Sprintf("%t", r.HostNetwork), fmt.Sprintf("%t", r.Service), fmt.Sprintf("%d", r.MessageSize), fmt.Sprintf("%t", r.SameNode),
 			fmt.Sprintf("%f", scpu.Idle), fmt.Sprintf("%f", scpu.User), fmt.Sprintf("%f", scpu.System), fmt.Sprintf("%f", scpu.Steal), fmt.Sprintf("%f", scpu.Iowait), fmt.Sprintf("%f", scpu.Nice), fmt.Sprintf("%f", scpu.Softirq), fmt.Sprintf("%f", scpu.Irq),
 		})
 	}
@@ -155,11 +163,13 @@ func ShowNodeCPU(s ScenarioResults) {
 
 // Abstracts out the common code for results
 func renderResults(s ScenarioResults, testType string) {
-	table := initTable([]string{"Result Type", "Scenario", "Parallelism", "Host Network", "Service", "Message Size", "Same node", "Duration", "Samples", "Avg value"})
+	table := initTable([]string{"Result Type", "Driver", "Scenario", "Parallelism", "Host Network", "Service", "Message Size", "Same node", "Duration", "Samples", "Avg value"})
 	for _, r := range s.Results {
 		if strings.Contains(r.Profile, testType) {
-			avg, _ := Average(r.ThroughputSummary)
-			table.Append([]string{fmt.Sprintf("%s Results", strings.Title(strings.ToLower(testType))), r.Profile, strconv.Itoa(r.Parallelism), strconv.FormatBool(r.HostNetwork), strconv.FormatBool(r.Service), strconv.Itoa(r.MessageSize), strconv.FormatBool(r.SameNode), strconv.Itoa(r.Duration), strconv.Itoa(r.Samples), fmt.Sprintf("%f (%s)", avg, r.Metric)})
+			if len(r.Driver) > 0 {
+				avg, _ := Average(r.ThroughputSummary)
+				table.Append([]string{fmt.Sprintf("📊 %s Results", strings.Title(strings.ToLower(testType))), r.Driver, r.Profile, strconv.Itoa(r.Parallelism), strconv.FormatBool(r.HostNetwork), strconv.FormatBool(r.Service), strconv.Itoa(r.MessageSize), strconv.FormatBool(r.SameNode), strconv.Itoa(r.Duration), strconv.Itoa(r.Samples), fmt.Sprintf("%f (%s)", avg, r.Metric)})
+			}
 		}
 	}
 	table.Render()
@@ -167,16 +177,17 @@ func renderResults(s ScenarioResults, testType string) {
 
 // ShowStreamResult accepts NetPerfResults to display to the user via stdout
 func ShowStreamResult(s ScenarioResults) {
-    if checkResults(s, "STREAM") {
+	if checkResults(s, "STREAM") {
+		logging.Debug("Rendering Stream results")
 		renderResults(s, "STREAM")
-    }
+	}
 }
 
 // ShowRRResult will display the RR performance results
 // Currently showing the Avg Value.
-// TODO: Capture latency values
 func ShowRRResult(s ScenarioResults) {
 	if checkResults(s, "RR") {
+		logging.Debug("Rendering RR results")
 		renderResults(s, "RR")
 	}
 }
@@ -185,11 +196,16 @@ func ShowRRResult(s ScenarioResults) {
 func ShowLatencyResult(s ScenarioResults) {
 	testTypes := []string{"STREAM", "RR"}
 	for _, testType := range testTypes {
-		table := initTable([]string{"Result Type", "Scenario", "Parallelism", "Host Network", "Service", "Message Size", "Same node", "Duration", "Samples", "99%tile value"})
+		if !checkResults(s, testType) {
+			continue
+		}
+		table := initTable([]string{"Result Type", "Driver", "Scenario", "Parallelism", "Host Network", "Service", "Message Size", "Same node", "Duration", "Samples", "99%tile value"})
 		for _, r := range s.Results {
-			if strings.Contains(r.Profile, testType) {
-				avg, _ := Average(r.ThroughputSummary)
-				table.Append([]string{fmt.Sprintf("%s Latency Results", strings.Title(strings.ToLower(testType))), r.Profile, strconv.Itoa(r.Parallelism), strconv.FormatBool(r.HostNetwork), strconv.FormatBool(r.Service), strconv.Itoa(r.MessageSize), strconv.FormatBool(r.SameNode), strconv.Itoa(r.Duration), strconv.Itoa(r.Samples), fmt.Sprintf("%f (%s)", avg, "usec")})
+			if r.Driver == "netperf" {
+				if strings.Contains(r.Profile, testType) {
+					avg, _ := Average(r.LatencySummary)
+					table.Append([]string{fmt.Sprintf("📊 %s Latency Results", strings.Title(strings.ToLower(testType))), r.Driver, r.Profile, strconv.Itoa(r.Parallelism), strconv.FormatBool(r.HostNetwork), strconv.FormatBool(r.Service), strconv.Itoa(r.MessageSize), strconv.FormatBool(r.SameNode), strconv.Itoa(r.Duration), strconv.Itoa(r.Samples), fmt.Sprintf("%f (%s)", avg, "usec")})
+				}
 			}
 		}
 		table.Render()

--- a/pkg/sample/types.go
+++ b/pkg/sample/types.go
@@ -6,4 +6,5 @@ type Sample struct {
 	Latency99ptile float64
 	Throughput     float64
 	Metric         string
+	Driver         string
 }


### PR DESCRIPTION
Adding iperf3 as a workload driver.

- Creates a new iperf3 service 
- Sets the Servers to have both netserver and iperf3 servers running
- [NOTE] Not tracking the latency/rtt yet with iperf 3, only looking at the throughput data currently. 