### PR TITLE
Fix RR results

### DIFF
--- a/pkg/results/result.go
+++ b/pkg/results/result.go
@@ -183,15 +183,12 @@ func ShowRRResult(s ScenarioResults) {
 
 // ShowLatencyResult accepts NetPerfResults to display to the user via stdout
 func ShowLatencyResult(s ScenarioResults) {
-	testTypes := []string{"STREAM", "RR"}
-	for _, testType := range testTypes {
-		table := initTable([]string{"Result Type", "Scenario", "Parallelism", "Host Network", "Service", "Message Size", "Same node", "Duration", "Samples", "99%tile value"})
-		for _, r := range s.Results {
-			if strings.Contains(r.Profile, testType) {
-				avg, _ := Average(r.ThroughputSummary)
-				table.Append([]string{fmt.Sprintf("%s Latency Results", strings.Title(strings.ToLower(testType))), r.Profile, strconv.Itoa(r.Parallelism), strconv.FormatBool(r.HostNetwork), strconv.FormatBool(r.Service), strconv.Itoa(r.MessageSize), strconv.FormatBool(r.SameNode), strconv.Itoa(r.Duration), strconv.Itoa(r.Samples), fmt.Sprintf("%f (%s)", avg, "usec")})
-			}
-		}
-		table.Render()
-	}
+        table := initTable([]string{"Result Type", "Scenario", "Parallelism", "Host Network", "Service", "Message Size", "Same node", "Duration", "Samples", "Avg 99%tile value"})
+        for _, r := range s.Results {
+                if strings.Contains(r.Profile, "RR") {
+                        p99, _ := Average(r.LatencySummary)
+                        table.Append([]string{"RR Latency Results", r.Profile, strconv.Itoa(r.Parallelism), strconv.FormatBool(r.HostNetwork), strconv.FormatBool(r.Service), strconv.Itoa(r.MessageSize), strconv.FormatBool(r.SameNode), strconv.Itoa(r.Duration), strconv.Itoa(r.Samples), fmt.Sprintf("%f (%s)", p99, "usec")})
+                }
+        }
+        table.Render()
 }


### PR DESCRIPTION
This patch does the following:
1. Removes Latency result for stream test as it is not relevant
2. Fixes a bug where the ThroughputSummary instead of LatencySummary was being used for summarizing P99 latency in the result table

Before Patch

```
+----------------+------------+-------------+--------------+---------+--------------+-----------+----------+---------+--------------------+
|  RESULT TYPE   |  SCENARIO  | PARALLELISM | HOST NETWORK | SERVICE | MESSAGE SIZE | SAME NODE | DURATION | SAMPLES |     AVG VALUE      |
+----------------+------------+-------------+--------------+---------+--------------+-----------+----------+---------+--------------------+
| Stream Results | TCP_STREAM | 1           | false        | false   | 1024         | false     | 5        | 2       | 4847.530000 (Mb/s) |
+----------------+------------+-------------+--------------+---------+--------------+-----------+----------+---------+--------------------+
+-------------+----------+-------------+--------------+---------+--------------+-----------+----------+---------+--------------------+
| RESULT TYPE | SCENARIO | PARALLELISM | HOST NETWORK | SERVICE | MESSAGE SIZE | SAME NODE | DURATION | SAMPLES |     AVG VALUE      |
+-------------+----------+-------------+--------------+---------+--------------+-----------+----------+---------+--------------------+
| Rr Results  | TCP_RR   | 1           | false        | false   | 1024         | false     | 5        | 2       | 8934.885000 (OP/s) |
+-------------+----------+-------------+--------------+---------+--------------+-----------+----------+---------+--------------------+
+------------------------+------------+-------------+--------------+---------+--------------+-----------+----------+---------+--------------------+
|      RESULT TYPE       |  SCENARIO  | PARALLELISM | HOST NETWORK | SERVICE | MESSAGE SIZE | SAME NODE | DURATION | SAMPLES |   99%TILE VALUE    |
+------------------------+------------+-------------+--------------+---------+--------------+-----------+----------+---------+--------------------+
| Stream Latency Results | TCP_STREAM | 1           | false        | false   | 1024         | false     | 5        | 2       | 4847.530000 (usec) |
+------------------------+------------+-------------+--------------+---------+--------------+-----------+----------+---------+--------------------+
+--------------------+----------+-------------+--------------+---------+--------------+-----------+----------+---------+--------------------+
|    RESULT TYPE     | SCENARIO | PARALLELISM | HOST NETWORK | SERVICE | MESSAGE SIZE | SAME NODE | DURATION | SAMPLES |   99%TILE VALUE    |
+--------------------+----------+-------------+--------------+---------+--------------+-----------+----------+---------+--------------------+
| Rr Latency Results | TCP_RR   | 1           | false        | false   | 1024         | false     | 5        | 2       | 8934.885000 (usec) |
+--------------------+----------+-------------+--------------+---------+--------------+-----------+----------+---------+--------------------+

```

After patch

```
+----------------+------------+-------------+--------------+---------+--------------+-----------+----------+---------+--------------------+
|  RESULT TYPE   |  SCENARIO  | PARALLELISM | HOST NETWORK | SERVICE | MESSAGE SIZE | SAME NODE | DURATION | SAMPLES |     AVG VALUE      |
+----------------+------------+-------------+--------------+---------+--------------+-----------+----------+---------+--------------------+
| Stream Results | TCP_STREAM | 1           | false        | false   | 1024         | false     | 5        | 2       | 4922.180000 (Mb/s) |
+----------------+------------+-------------+--------------+---------+--------------+-----------+----------+---------+--------------------+
+-------------+----------+-------------+--------------+---------+--------------+-----------+----------+---------+--------------------+
| RESULT TYPE | SCENARIO | PARALLELISM | HOST NETWORK | SERVICE | MESSAGE SIZE | SAME NODE | DURATION | SAMPLES |     AVG VALUE      |
+-------------+----------+-------------+--------------+---------+--------------+-----------+----------+---------+--------------------+
| Rr Results  | TCP_RR   | 1           | false        | false   | 1024         | false     | 5        | 2       | 8853.965000 (OP/s) |
+-------------+----------+-------------+--------------+---------+--------------+-----------+----------+---------+--------------------+
+--------------------+----------+-------------+--------------+---------+--------------+-----------+----------+---------+-------------------+
|    RESULT TYPE     | SCENARIO | PARALLELISM | HOST NETWORK | SERVICE | MESSAGE SIZE | SAME NODE | DURATION | SAMPLES | AVG 99%TILE VALUE |
+--------------------+----------+-------------+--------------+---------+--------------+-----------+----------+---------+-------------------+
| RR Latency Results | TCP_RR   | 1           | false        | false   | 1024         | false     | 5        | 2       | 176.500000 (usec) |
+--------------------+----------+-------------+--------------+---------+--------------+-----------+----------+---------+-------------------+

```