### PR TITLE
Allow the user to pass `--json` for json output

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ $ oc adm policy add-scc-to-user hostnetwork -z netperf
 ```shell
 $ kubectl create ns netperf
 $ kubectl create sa netperf -n netperf
-$ ./bin/arch/k8s-netperf --help
+$ ./bin/amd64/k8s-netperf --help
 A tool to run network performance tests in Kubernetes cluster
 
 Usage:
@@ -60,6 +60,7 @@ Flags:
       --debug                 Enable debug log
   -h, --help                  help for k8s-netperf
       --iperf                 Use iperf3 as load driver (along with netperf)
+      --json                  Instead of human-readable output, return JSON to stdout
       --local                 Run network performance tests with pod/server on the same node
       --metrics               Show all system metrics retrieved from prom
       --prom string           Prometheus URL
@@ -67,6 +68,8 @@ Flags:
       --tcp-tolerance float   Allowed %diff from hostNetwork to podNetwork, anything above tolerance will result in k8s-netperf exiting 1. (default 10)
       --uuid string           User provided UUID
 ```
+
+Running with `--json` will reduce all output to just the JSON result, allowing users to feed the result to `jq` or other tools. Only output to the screen will be the result JSON or errors. 
 
 `--prom` accepts a string (URL). Example  http://localhost:9090
 

--- a/cmd/k8s-netperf/k8s-netperf.go
+++ b/cmd/k8s-netperf/k8s-netperf.go
@@ -34,6 +34,7 @@ var (
 	searchURL   string
 	showMetrics bool
 	tcpt        float64
+	json        bool
 )
 
 var rootCmd = &cobra.Command{
@@ -46,6 +47,10 @@ var rootCmd = &cobra.Command{
 		} else {
 			u := uuid.New()
 			uid = fmt.Sprintf("%s", u.String())
+		}
+
+		if json {
+			log.SetError()
 		}
 
 		if debug {
@@ -202,12 +207,16 @@ var rootCmd = &cobra.Command{
 			}
 		}
 
-		result.ShowStreamResult(sr)
-		result.ShowRRResult(sr)
-		result.ShowLatencyResult(sr)
-		if showMetrics {
-			result.ShowNodeCPU(sr)
-			result.ShowPodCPU(sr)
+		if !json {
+			result.ShowStreamResult(sr)
+			result.ShowRRResult(sr)
+			result.ShowLatencyResult(sr)
+			if showMetrics {
+				result.ShowNodeCPU(sr)
+				result.ShowPodCPU(sr)
+			}
+		} else {
+			archive.WriteJSONResult(sr)
 		}
 		err = archive.WriteCSVResult(sr)
 		if err != nil {
@@ -312,6 +321,7 @@ func executeWorkload(nc config.Config, s config.PerfScenarios, hostNet bool, ipe
 func main() {
 	rootCmd.Flags().StringVar(&cfgfile, "config", "netperf.yml", "K8s netperf Configuration File")
 	rootCmd.Flags().BoolVar(&iperf3, "iperf", false, "Use iperf3 as load driver (along with netperf)")
+	rootCmd.Flags().BoolVar(&json, "json", false, "Instead of human-readable output, return JSON to stdout")
 	rootCmd.Flags().BoolVar(&nl, "local", false, "Run network performance tests with pod/server on the same node")
 	rootCmd.Flags().BoolVar(&full, "all", false, "Run all tests scenarios - hostNet and podNetwork (if possible)")
 	rootCmd.Flags().BoolVar(&debug, "debug", false, "Enable debug log")

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -231,6 +231,20 @@ func WritePromCSVResult(r result.ScenarioResults) error {
 	return nil
 }
 
+// WriteJSONResult sends the results as JSON to stdout
+func WriteJSONResult(r result.ScenarioResults) error {
+	docs, err := BuildDocs(r, "k8s-netperf")
+	if err != nil {
+		return err
+	}
+	p, err := json.MarshalIndent(docs, " ", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(p))
+	return nil
+}
+
 // WriteCSVResult will write the throughput result to the local filesystem
 func WriteCSVResult(r result.ScenarioResults) error {
 	d := time.Now().Unix()

--- a/pkg/logging/log.go
+++ b/pkg/logging/log.go
@@ -25,6 +25,11 @@ func init() {
 	defaultLog = new()
 }
 
+// SetError - Switch to ERROR level
+func SetError() {
+	SetLevel(defaultLog, logrus.ErrorLevel)
+}
+
 // SetDebug - Switch to DEBUG level
 func SetDebug() {
 	SetLevel(defaultLog, logrus.DebugLevel)


### PR DESCRIPTION
Instead of using the table format, allow the user to pass a option to emit a JSON document with the results.

Closes #35