### PR TITLE
fix: Adds k8s-netperf to the container image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ container-build: build
 	@echo "Building the container image"
 	$(CONTAINER_BUILD) -f containers/Containerfile \
 		--build-arg RHEL_VERSION=$(RHEL_VERSION) \
-		-t $(CONTAINER_NS)/$(BIN):latest ./containers
+		-t $(CONTAINER_NS)/$(BIN):latest .
 
 gha-build:
 	@echo "Building the container image for GHA"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ make build
 ```shell
 $ git clone http://github.com/cloud-bulldozer/k8s-netperf
 $ cd k8s-netperf
-$ make docker-build
+$ make container-build
 ```
 
 ## Running

--- a/README.md
+++ b/README.md
@@ -95,6 +95,23 @@ Flags:
 
 > *Note: With OpenShift, we attempt to discover the OpenShift route. If that route is not reachable, it might be required to `port-forward` the service and pass that via the `--prom` option.*
 
+## Running in a Container
+
+You can also run `k8s-netperf` in a container. Here is an example command on how to execute it:
+
+```shell
+$ podman run -v ~/.kube/config:/root/.kube/config -v $(pwd)/netperf.yml:/netperf.yml quay.io/cloud-bulldozer/k8s-netperf:latest k8s-netperf --config /netperf.yml
+```
+
+This command does the following:
+
+* ```-v ~/.kube/config:/root/.kube/config```: Mounts your local kubeconfig into the container at /root/.kube/config. This allows k8s-netperf to interact with your Kubernetes cluster.
+* ```-v $(pwd)/netperf.yml:/netperf.yml```: Mounts your local netperf.yml configuration file into the container at /netperf.yml.
+* ```quay.io/cloud-bulldozer/k8s-netperf:latest```: Specifies the container image to run. In this case, it's the latest version of k8s-netperf from quay.io.
+* ```k8s-netperf --config /netperf.yml```: The command to run inside the container. This starts k8s-netperf with your configuration file.
+
+Please replace `~/.kube/config` and `$(pwd)/netperf.yml` with the paths to your kubeconfig and `netperf.yml` files, respectively.
+
 ### Config file
 #### Config File v2
 The v2 config file will be executed in the order the tests are presented in the config file.

--- a/containers/Containerfile
+++ b/containers/Containerfile
@@ -1,10 +1,29 @@
 # RHEL_VERSION defined in Makefile
+FROM golang:1.19 AS builder
+# smoke test to verify if golang is available
+RUN go version
+
+ARG PROJECT_VERSION=latest
+
+COPY . /go/src/github.com/jtaleric/k8s-netperf/
+WORKDIR /go/src/github.com/jtaleric/k8s-netperf/
+RUN set -Eeux && \
+    go mod download && \
+    go mod verify
+
+RUN GOOS=linux GOARCH=amd64 \
+    go build \
+    -trimpath \
+    -ldflags="-w -s -X 'main.Version=${PROJECT_VERSION}'" \
+    -o ./k8s-netperf cmd/k8s-netperf/k8s-netperf.go
+RUN go test -cover -v ./...
+
 ARG RHEL_VERSION
 FROM registry.access.redhat.com/${RHEL_VERSION}:latest
 
-COPY appstream.repo /etc/yum.repos.d/centos8-appstream.repo
+COPY ./containers/appstream.repo /etc/yum.repos.d/centos8-appstream.repo
 
-COPY netperf.diff /tmp/netperf.diff
+COPY ./containers/netperf.diff /tmp/netperf.diff
 RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && dnf clean all
 RUN dnf install -y uperf && dnf clean all
 
@@ -31,4 +50,6 @@ RUN curl -L https://github.com/esnet/iperf/releases/download/3.16/iperf-3.16.tar
 
 RUN rm -rf netperf && \
     dnf clean all
-COPY super-netperf /usr/bin/super-netperf
+COPY ./containers/super-netperf /usr/bin/super-netperf
+
+COPY --from=builder /go/src/github.com/jtaleric/k8s-netperf/k8s-netperf /usr/bin/k8s-netperf


### PR DESCRIPTION
This commit adds a go build to the Containerfile via multi-stage build. For this to work, also the Makefile was change to load the full repo into the container build context.

This also adds a simple example to the docs section on how to use the container image to performe the tests.

This PR also fixes a wrong command in the docs to build the container image